### PR TITLE
remove =default on command_line_args ctor, as gcc 4.8 (default on ubu…

### DIFF
--- a/src/command_line_args.cpp
+++ b/src/command_line_args.cpp
@@ -10,7 +10,11 @@
 namespace node_clang
 {
 
-command_line_args::command_line_args(const v8::Local<v8::Array>& js_command_line_args)
+command_line_args::command_line_args() noexcept
+{
+}
+
+command_line_args::command_line_args(const v8::Local<v8::Array>& js_command_line_args) noexcept
 {
     std::uint32_t length = js_command_line_args->Length();
     _data.reserve(length + 1);

--- a/src/command_line_args.hpp
+++ b/src/command_line_args.hpp
@@ -24,8 +24,8 @@ class command_line_args final
     NODE_CLANG_NO_MOVEABLE(command_line_args);
 
 public:
-    explicit command_line_args() noexcept = default;
-    explicit command_line_args(const v8::Local<v8::Array>& js_command_line_args);
+    explicit command_line_args() noexcept;
+    explicit command_line_args(const v8::Local<v8::Array>& js_command_line_args) noexcept;
     ~command_line_args() noexcept;
 
     const char* const* data() const& noexcept

--- a/src/defines.hpp
+++ b/src/defines.hpp
@@ -12,13 +12,3 @@
 #define NODE_CLANG_NO_MOVEABLE(CLASS)         \
     CLASS(CLASS&&) = delete;                  \
     CLASS& operator=(CLASS&&) = delete
-
-/// defaults copy ctor and assignment
-#define NODE_CLANG_DEFAULT_COPYABLE(CLASS)    \
-    CLASS(const CLASS&) = default;            \
-    CLASS& operator=(const CLASS&) = default
-
-/// defaults move ctor and assignment
-#define NODE_CLANG_DEFAULT_MOVEABLE(CLASS)    \
-    CLASS(CLASS&&) = default;                 \
-    CLASS& operator=(CLASS&&) = default


### PR DESCRIPTION
…ntu 14.04) seems to have compile issues with it